### PR TITLE
[FEATURE] Added iterations to most parts of the benchmark + Memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,17 @@ If you would like to use AMD/Nvidia GPU for acceleration, check this:
 Run benchmark script to compute performance on your device:
 
 ```bash
-python benchmark.py [--iter NB_OF_ITERATIONS]
+python benchmark.py
 ```
 
- --iter NB_OF_ITERATIONS (optional, default=5): Use this option to specify the number of iterations for the benchmark.
+You can also select the number of times the benchmark will be run :
+
+```bash
+python benchmark.py --iter NB_OF_ITERATIONS
+```
+
+ By default, the number of iterations is 5, but if you want a faster result or a more accurate one 
+ you can set it to whatever value you want, but please only report results with at least 5 iterations.
 
 `benchmark.py` will load the same `.env` as `app.py`.
 

--- a/README.md
+++ b/README.md
@@ -186,8 +186,10 @@ If you would like to use AMD/Nvidia GPU for acceleration, check this:
 Run benchmark script to compute performance on your device:
 
 ```bash
-python benchmark.py
+python benchmark.py [--iter NB_OF_ITERATIONS]
 ```
+
+ --iter NB_OF_ITERATIONS (optional, default=5): Use this option to specify the number of iterations for the benchmark.
 
 `benchmark.py` will load the same `.env` as `app.py`.
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -6,6 +6,7 @@ from dotenv import load_dotenv
 from distutils.util import strtobool
 from llama2_wrapper import LLAMA2_WRAPPER
 from memory_profiler import memory_usage
+from tqdm import tqdm
 
 def run_iteration(llama2_wrapper, prompt_example, DEFAULT_SYSTEM_PROMPT, DEFAULT_MAX_NEW_TOKENS):
     def generation():
@@ -32,7 +33,7 @@ def run_iteration(llama2_wrapper, prompt_example, DEFAULT_SYSTEM_PROMPT, DEFAULT
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--iter", type=int, default=1, help="Number of iterations")
+    parser.add_argument("--iter", type=int, default=5, help="Number of iterations")
     args = parser.parse_args()
 
     load_dotenv()
@@ -80,15 +81,14 @@ def main():
     total_memory_gen = 0
 
     prompt_example = "Can you explain briefly to me what is the Python programming language?"
-    model_response = ""
 
     # Cold run
     print("Performing cold run...")
     run_iteration(llama2_wrapper, prompt_example, DEFAULT_SYSTEM_PROMPT, DEFAULT_MAX_NEW_TOKENS)
 
     # Timed runs
-    print("Performing timed runs...")
-    for _ in range(args.iter):
+    print(f"Performing {args.iter} timed runs...")
+    for _ in tqdm(range(args.iter)):
         gen_time, tokens_per_sec, mem_gen, model_response = run_iteration(llama2_wrapper, prompt_example, DEFAULT_SYSTEM_PROMPT, DEFAULT_MAX_NEW_TOKENS)
         total_time += gen_time
         total_tokens_per_second += tokens_per_sec
@@ -101,7 +101,7 @@ def main():
     print(f"Initialization time: {initialization_time:0.4f} seconds.")
     print(f"Average generation time over {args.iter} iterations: {avg_time:0.4f} seconds.")
     print(f"Average speed over {args.iter} iterations: {avg_tokens_per_second:0.4f} tokens/sec.")
-    print(f"Average memory during generation: {avg_memory_gen:.2f} MiB")
+    print(f"Average memory usage during generation: {avg_memory_gen:.2f} MiB")
 
 if __name__ == "__main__":
     main()

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,43 +1,52 @@
 import os
 import time
+import argparse
 
 from dotenv import load_dotenv
 from distutils.util import strtobool
-
 from llama2_wrapper import LLAMA2_WRAPPER
+from memory_profiler import memory_usage
 
+def run_iteration(llama2_wrapper, prompt_example, DEFAULT_SYSTEM_PROMPT, DEFAULT_MAX_NEW_TOKENS):
+    def generation():
+        generator = llama2_wrapper.run(
+            prompt_example, [], DEFAULT_SYSTEM_PROMPT, DEFAULT_MAX_NEW_TOKENS, 1, 0.95, 50
+        )
+        model_response = None
+        try:
+            first_model_response = next(generator)
+        except StopIteration:
+            pass
+        for model_response in generator:
+            pass
+        return llama2_wrapper.get_token_length(model_response), model_response
+
+    tic = time.perf_counter()
+    mem_usage, (output_token_length, model_response) = memory_usage((generation, ), max_usage=True, retval=True)
+    toc = time.perf_counter()
+
+    generation_time = toc - tic
+    tokens_per_second = output_token_length / generation_time
+
+    return generation_time, tokens_per_second, mem_usage, model_response
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iter", type=int, default=1, help="Number of iterations")
+    args = parser.parse_args()
+
     load_dotenv()
 
-    DEFAULT_SYSTEM_PROMPT = (
-        os.getenv("DEFAULT_SYSTEM_PROMPT")
-        if os.getenv("DEFAULT_SYSTEM_PROMPT") is not None
-        else ""
-    )
-    MAX_MAX_NEW_TOKENS = (
-        int(os.getenv("MAX_MAX_NEW_TOKENS"))
-        if os.getenv("DEFAULT_MAX_NEW_TOKENS") is not None
-        else 2048
-    )
-    DEFAULT_MAX_NEW_TOKENS = (
-        int(os.getenv("DEFAULT_MAX_NEW_TOKENS"))
-        if os.getenv("DEFAULT_MAX_NEW_TOKENS") is not None
-        else 1024
-    )
-    MAX_INPUT_TOKEN_LENGTH = (
-        int(os.getenv("MAX_INPUT_TOKEN_LENGTH"))
-        if os.getenv("MAX_INPUT_TOKEN_LENGTH") is not None
-        else 4000
-    )
+    DEFAULT_SYSTEM_PROMPT = os.getenv("DEFAULT_SYSTEM_PROMPT", "")
+    MAX_MAX_NEW_TOKENS = int(os.getenv("MAX_MAX_NEW_TOKENS", 2048))
+    DEFAULT_MAX_NEW_TOKENS = int(os.getenv("DEFAULT_MAX_NEW_TOKENS", 1024))
+    MAX_INPUT_TOKEN_LENGTH = int(os.getenv("MAX_INPUT_TOKEN_LENGTH", 4000))
 
     MODEL_PATH = os.getenv("MODEL_PATH")
     assert MODEL_PATH is not None, f"MODEL_PATH is required, got: {MODEL_PATH}"
 
     LOAD_IN_8BIT = bool(strtobool(os.getenv("LOAD_IN_8BIT", "True")))
-
     LOAD_IN_4BIT = bool(strtobool(os.getenv("LOAD_IN_4BIT", "True")))
-
     LLAMA_CPP = bool(strtobool(os.getenv("LLAMA_CPP", "True")))
 
     if LLAMA_CPP:
@@ -58,36 +67,43 @@ def main():
         "MAX_INPUT_TOKEN_LENGTH": MAX_INPUT_TOKEN_LENGTH,
     }
 
-    tic = time.perf_counter()
+    # Initialization
+    init_tic = time.perf_counter()
     llama2_wrapper = LLAMA2_WRAPPER(config)
     llama2_wrapper.init_tokenizer()
     llama2_wrapper.init_model()
-    toc = time.perf_counter()
-    print(f"Initialize the model in {toc - tic:0.4f} seconds.")
+    init_toc = time.perf_counter()
+    initialization_time = init_toc - init_tic
 
-    example = "Can you explain briefly to me what is the Python programming language?"
+    total_time = 0
+    total_tokens_per_second = 0
+    total_memory_gen = 0
 
-    generator = llama2_wrapper.run(
-        example, [], DEFAULT_SYSTEM_PROMPT, DEFAULT_MAX_NEW_TOKENS, 1, 0.95, 50
-    )
-    tic = time.perf_counter()
-    try:
-        first_response = next(generator)
-        # history += [(example, first_response)]
-    except StopIteration:
-        pass
-        # history += [(example, "")]
-    for response in generator:
-        # history += [(example, response)]
-        pass
-    print(response)
+    prompt_example = "Can you explain briefly to me what is the Python programming language?"
+    model_response = ""
 
-    toc = time.perf_counter()
-    output_token_length = llama2_wrapper.get_token_length(response)
+    # Cold run
+    print("Performing cold run...")
+    run_iteration(llama2_wrapper, prompt_example, DEFAULT_SYSTEM_PROMPT, DEFAULT_MAX_NEW_TOKENS)
 
-    print(f"Generating the out in {toc - tic:0.4f} seconds.")
-    print(f"Speed: {output_token_length / (toc - tic):0.4f} tokens/sec.")
+    # Timed runs
+    print("Performing timed runs...")
+    for _ in range(args.iter):
+        gen_time, tokens_per_sec, mem_gen, model_response = run_iteration(llama2_wrapper, prompt_example, DEFAULT_SYSTEM_PROMPT, DEFAULT_MAX_NEW_TOKENS)
+        total_time += gen_time
+        total_tokens_per_second += tokens_per_sec
+        total_memory_gen += mem_gen
+    avg_time = total_time / args.iter
+    avg_tokens_per_second = total_tokens_per_second / args.iter
+    avg_memory_gen = total_memory_gen / args.iter
 
+    print(f"Last model response: {model_response}")
+    print(f"Initialization time: {initialization_time:0.4f} seconds.")
+    print(f"Average generation time over {args.iter} iterations: {avg_time:0.4f} seconds.")
+    print(f"Average speed over {args.iter} iterations: {avg_tokens_per_second:0.4f} tokens/sec.")
+    print(f"Average memory during generation: {avg_memory_gen:.2f} MiB")
 
 if __name__ == "__main__":
     main()
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ transformers==4.31.0
 tqdm==4.65.0
 python-dotenv==1.0.0
 llama-cpp-python== 0.1.77
+memory-profiler==0.61.0


### PR DESCRIPTION
So here the implementation for adding `--iter NB_OF_ITERATIONS` as an optional argument to the benchmark.

For the moment I've set the default to 1 iteration as asked but I'm not sure that ideal, maybe 5 or 10 would be more representative of an average result.
I haven't added the iteration of the init part for two reason:

1. I don't really know how to scramble/flush all the caches involved such that the time is representative of a fresh initialization. That's one reason why the benchmark of my processor has an init time so low, it seems that most of the model was kept in memory instead of reloaded from the main storage (and even in this case, there is also the DRAM cache of the SSD that would be involved), so it is complicated to fix all of that.

2. It would spam the terminal to do so with the messages generated by llama.cpp at initialization, and I have no idea how to prevent that without modifying the cpp file.

As a bonus, I've added the report of the RAM usage using memory-profiler and added the library as a requirement in the requirement.txt of the project, so now it should be easier for user to instantly see the info they should report. 

There is one cold run before all the iterations such that it fills correctly all the caches such that it would better correspond to the average performance of using this tool. And only the last response of the model is displayed such that it doesn't really spam the terminal output.

If you have anything you want me to change, just ask and will do my best to accommodate such that it can be merged !
