### PR TITLE
Supports accepting network requests, listening on specific ports and running GPTQ models on multiple GPUs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ dist
 .DS_Store
 .vscode
 
+.venv
+venv
+
 __pycache__
 gradio_cached_examples
 

--- a/README.md
+++ b/README.md
@@ -308,6 +308,8 @@ Make sure you have downloaded the 4-bit model from `Llama-2-7b-Chat-GPTQ` and se
 If you encounter issue like `NameError: name 'autogptq_cuda_256' is not defined`, please refer to [here](https://huggingface.co/TheBloke/open-llama-13b-open-instruct-GPTQ/discussions/1)
 > pip install https://github.com/PanQiWei/AutoGPTQ/releases/download/v0.3.0/auto_gptq-0.3.0+cu117-cp310-cp310-linux_x86_64.whl  
 
+If you have multiple GPUs, you need to set the maximum usage of memory for each GPU through the parameter `--gptq_gpu_memory`. Otherwise, memory will only be allocated on the first GPU. If first GPU's memory is not enough, this will cause an error: `torch.cuda.OutOfMemoryError : CUDA out of memory.`. An example running on 24GB memory dual GPUs: `--gptq_gpu_memory "0:23GiB,1:23GiB"`.
+
 ### Run on CPU
 
 Run Llama-2 model on CPU requires [llama.cpp](https://github.com/ggerganov/llama.cpp) dependency and [llama.cpp Python Bindings](https://github.com/abetlen/llama-cpp-python), which are already installed. 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Use default model path: ./models/llama-2-7b-chat.Q4_0.gguf
 Start downloading model to: ./models/llama-2-7b-chat.Q4_0.gguf
 ```
 
-You can also customize your `MODEL_PATH`, `BACKEND_TYPE,` and model configs in `.env` file to run different llama2 models on different backends (llama.cpp, transformers, gptq). 
+You can also customize your `MODEL_PATH`, `BACKEND_TYPE,` and model configs in `.env` file to run different llama2 models on different backends (llama.cpp, transformers, gptq). You can use the `--listen` to allow network requests, use the `--port` to specify listening port.
 
 ### Start Code Llama UI
 

--- a/app.py
+++ b/app.py
@@ -23,6 +23,13 @@ def main():
         help="Backend options: llama.cpp, gptq, transformers",
     )
     parser.add_argument(
+        "--gptq_gpu_memory",
+        type=str,
+        default="",
+        help="Set GPU maximum memory for GPTQ backend to use multiple GPUs, "
+             "e.g. \"0:23GiB,1:23GiB\"",
+    )
+    parser.add_argument(
         "--load_in_8bit",
         type=bool,
         default=False,
@@ -61,6 +68,7 @@ def main():
     assert BACKEND_TYPE is not None, f"BACKEND_TYPE is required, got: {BACKEND_TYPE}"
 
     LOAD_IN_8BIT = bool(strtobool(os.getenv("LOAD_IN_8BIT", "True")))
+    GPTQ_GPU_MEMORY = args.gptq_gpu_memory
 
     if args.model_path != "":
         MODEL_PATH = args.model_path
@@ -74,6 +82,7 @@ def main():
         backend_type=BACKEND_TYPE,
         max_tokens=MAX_INPUT_TOKEN_LENGTH,
         load_in_8bit=LOAD_IN_8BIT,
+        gptq_gpu_memory=GPTQ_GPU_MEMORY,
         # verbose=True,
     )
 

--- a/app.py
+++ b/app.py
@@ -34,6 +34,18 @@ def main():
         default=False,
         help="Whether to share public for gradio.",
     )
+    parser.add_argument(
+        "--listen",
+        type=bool,
+        default=False,
+        help="listen on 0.0.0.0, allowing to respond to network requests",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=7860,
+        help="port to listen on, default 7860",
+    )
     args = parser.parse_args()
 
     load_dotenv()
@@ -411,7 +423,15 @@ def main():
             api_name=False,
         )
 
-    demo.queue(max_size=20).launch(share=args.share)
+    launch_params = {
+        "share": args.share,
+        "server_port": args.port
+    }
+
+    if args.listen:
+        launch_params["server_name"] = "0.0.0.0"
+
+    demo.queue(max_size=20).launch(**launch_params)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If multiple GPUs are used to run the GPTQ model, memory would only be allocated on the first GPU, resulting in an error due to the inability to allocate more memory. This pr solves this problem. Also allow listening for network requests on specific ports, which is a necessary feature since the deployment environment is likely to not have a graphical interface.